### PR TITLE
Feat: Infinite scroll 커스텀 훅으로 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "wanted-codestates-project-7-9",
       "version": "0.1.0",
       "dependencies": {
+        "prop-types": "^15.8.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-icons": "^4.3.1",
@@ -13755,7 +13756,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "prop-types": "^15.8.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-icons": "^4.3.1",

--- a/src/hooks/useInfiniteScroll.js
+++ b/src/hooks/useInfiniteScroll.js
@@ -21,7 +21,7 @@ const useInfiniteScroll = ({ getMoreItems }) => {
       observer = new IntersectionObserver(onIntersect, { threshold: 0.4 });
       observer.observe(target);
     }
-    return () => observer && observer.disconnect();
+    return () => observer?.disconnect();
   });
 
   return {

--- a/src/hooks/useInfiniteScroll.js
+++ b/src/hooks/useInfiniteScroll.js
@@ -1,0 +1,32 @@
+import { useEffect, useState, useCallback } from 'react';
+
+const useInfiniteScroll = ({ getMoreItems }) => {
+  const [containerRef, setContainerRef] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const onIntersect = useCallback(async ([entry], observer) => {
+    if (entry.isIntersecting && !loading) {
+      observer.unobserve(entry.target);
+      await getMoreItems();
+      observer.observe(entry.target);
+    }
+  }, [getMoreItems, loading]);
+
+  useEffect(() => {
+    let observer;
+    const { current } = containerRef;
+    const { length } = current.children;
+    const target = length > 5 ? current.children[length - 5] : current.lastChild;
+    if (target) {
+      observer = new IntersectionObserver(onIntersect, { threshold: 0.4 });
+      observer.observe(target);
+    }
+    return () => observer && observer.disconnect();
+  });
+
+  return {
+    containerRef, setContainerRef, loading, setLoading,
+  };
+};
+
+export default useInfiniteScroll;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- prop-types 패키지를 설치했습니다. 
- Intersection Observer API를 사용해 infinite scroll을 구현했습니다. 
  - 리스트 아래에서 다섯번째 요소가 화면에 40% 정도 보이면
  다음 아이템들을 fetching하도록 구현했습니다. 
  (단, 리스트의 요소가 다섯 개 이하라면 리스트의 마지막 요소가 화면에 40% 정도 보였을 때)
  - useInfiniteScroll() 훅의 인자로 데이터를 추가로 fetching해오는 함수인 `getMoreItems`를 전달해야 합니다. 
  getMoreItems 예시
  ```js
    const getMoreItems = async () => {
      setLoading(true);
      // const items = await axios.get('api-url', { params: ... });
      setItemList((list) => list.concat(items));
      setLoading(false);
    };
  ```
 - useInfiniteScroll() 반환값으로 containerRef, setContainerRef(무한스크롤을 적용할 리스트 컨테이너의 ref), 그리고 loading, setLoading을 전달합니다. 

### 테스트 결과
data.json, setTimeout promise 사용해서 정상적으로 작동하는 거 확인했습니다. 

### Issue
related: #12 
