### PR TITLE
Fix: 중복 배열 키 값 해결

### DIFF
--- a/src/components/GridView.jsx
+++ b/src/components/GridView.jsx
@@ -7,19 +7,18 @@ import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import { setReviews } from '../redux/actions/review';
 import useInfiniteScroll from '../hooks/useInfiniteScroll';
-// import useData from '../hooks/useData';
 
 let page = 0;
 function GridView({ datas }) {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const listRef = useRef();
-  // const fetchData = useData();
   const getMoreItems = useCallback(async () => {
     setLoading(true);
     page += 1;
-    await dispatch(setReviews(page, 20));
+    await dispatch(setReviews(page, 20, datas));
     setLoading(false);
+    // eslint-disable-next-line
   }, [dispatch]);
   const { setContainerRef, setLoading } = useInfiniteScroll({ getMoreItems });
 

--- a/src/components/ListView/ListView.jsx
+++ b/src/components/ListView/ListView.jsx
@@ -1,29 +1,53 @@
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { useEffect, useRef, useCallback } from 'react';
 import Content from './Content';
 import Desc from './Desc';
 import Image from './Image';
 import InfoTop from './InfoTop';
 import SocialArea from './SocialArea';
 import Stars from './Stars';
-import Data from '../../data/data.json';
+import { setReviews } from '../../redux/actions/review';
+import useInfiniteScroll from '../../hooks/useInfiniteScroll';
 
-function ListView() {
+let page = 0;
+function ListView({ datas }) {
   const navigate = useNavigate();
   const detailPageClick = (id) => {
     navigate(`/details/${id}`);
   };
+
+  const dispatch = useDispatch();
+  const listRef = useRef();
+  const getMoreItems = useCallback(async () => {
+    setLoading(true);
+    page += 1;
+    await dispatch(setReviews(page, 20, datas));
+    setLoading(false);
+    // eslint-disable-next-line
+  }, [dispatch]);
+
+  const { setContainerRef, setLoading } = useInfiniteScroll({ getMoreItems });
+
+  useEffect(() => {
+    getMoreItems();
+    setContainerRef(listRef);
+  }, [getMoreItems, setContainerRef]);
+
   return (
     <>
-      {Data.map((item) => (
+      {datas.map((item) => (
         <ListPage
+          ref={listRef}
           key={item.id}
           onClick={() => detailPageClick(item.id)}
           onKeyDown={() => detailPageClick(item.id)}
           aria-hidden="true"
         >
           <InfoTop username={item.username} createdAt={item.createdAt} />
-          <Image src={item.src} />
+          <Image src={item.images[0].src} />
           <SocialArea likes={item.likes} />
           <Stars stars={item.stars} />
           <Desc description={item.description} />
@@ -39,3 +63,7 @@ export default ListView;
 const ListPage = styled.div`
   cursor: pointer;
 `;
+
+ListView.propTypes = {
+  datas: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.object])).isRequired,
+};

--- a/src/components/Tab.jsx
+++ b/src/components/Tab.jsx
@@ -54,7 +54,11 @@ function Tab() {
           </TabItem>
         ))}
       </TabRow>
-      {currentTab === 0 ? <GridView datas={sortedReviews} /> : <ListView />}
+      {currentTab === 0 ? (
+        <GridView datas={sortedReviews} />
+      ) : (
+        <ListView datas={sortedReviews} />
+      )}
     </TabWrap>
   );
 }

--- a/src/redux/reducers/review.js
+++ b/src/redux/reducers/review.js
@@ -16,7 +16,15 @@ export default function review(state = initialState, action = {}) {
     case SET_REVIEWS:
       return {
         ...state,
-        reviews: [...state.reviews, ...action.payload],
+        reviews: [...state.reviews, ...action.payload].reduce(
+          (acc, current) => {
+            if (acc.findIndex(({ id }) => id === current.id) === -1) {
+              acc.push(current);
+            }
+            return acc;
+          },
+          [],
+        ),
       };
     case REFRESH_REVIEWS:
       return {
@@ -32,20 +40,16 @@ export default function review(state = initialState, action = {}) {
     case LIKE_REVIEW:
       return {
         ...state,
-        reviews: state.reviews.map((data) => (
-          data.postNumber === action.payload
-            ? { ...data, likes: data.likes + 1 }
-            : data
-        )),
+        reviews: state.reviews.map((data) => (data.postNumber === action.payload
+          ? { ...data, likes: data.likes + 1 }
+          : data)),
       };
     case UNLIKE_REVIEW:
       return {
         ...state,
-        reviews: state.reviews.map((data) => (
-          data.postNumber === action.payload
-            ? { ...data, likes: data.likes - 1 }
-            : data
-        )),
+        reviews: state.reviews.map((data) => (data.postNumber === action.payload
+          ? { ...data, likes: data.likes - 1 }
+          : data)),
       };
     case SET_SORT_OPTION:
       return {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
무한 스크롤 구현 시 데이터 불러오는 과정에서 중복 키 값이 발생하였고, 중복된 데이터를 reduce함수를 이용하여 제거해주었습니다.
```
[...state.reviews, ...action.payload].reduce(
          (acc, current) => {
            if (acc.findIndex(({ id }) => id === current.id) === -1) {
              acc.push(current);
            }
            return acc;
          },
          [],
        ),
```
`배열.reduce((누적값, 현재값, 인덱스, 요소) => { return 결과 }, 초깃값);`으로 구성되기 때문에 
현재 id와 누적된 id값과 비교하여 같은 값이 없다면 acc에 넣어준 후 마지막에 acc를 리턴해준다.

### 테스트 결과
![ezgif com-gif-maker (38)](https://user-images.githubusercontent.com/59958929/157922350-167a1a50-d5d9-46db-ba80-47e5bd511a98.gif)


resolved: #5 
