### PR TITLE
Feature: sort query 적용 및 데이터 렌더링 오류 수정

### DIFF
--- a/src/components/GridView.jsx
+++ b/src/components/GridView.jsx
@@ -7,26 +7,32 @@ import { useDispatch, useSelector } from 'react-redux';
 import { setReviews } from '../redux/actions/review';
 import useInfiniteScroll from '../hooks/useInfiniteScroll';
 
-let page = 1;
 function GridView() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const listRef = useRef();
   const reviewList = useSelector((state) => state.review.reviews);
-  const sortOption = useSelector((state) => state.review.sortOption);
+  const fetchOptions = useSelector((state) => state.review.options);
 
   const getMoreItems = useCallback(() => {
-    setLoading(true);
-    page += 1;
-    dispatch(setReviews(page, 20, sortOption?.value));
-    setLoading(false);
+    if (fetchOptions?.pageNo) {
+      const { pageNo, perPage, sort } = fetchOptions;
+      setLoading(true);
+      dispatch(setReviews(pageNo + 1, perPage, sort));
+      setLoading(false);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dispatch]);
-  const { setContainerRef, setLoading } = useInfiniteScroll({ getMoreItems });
+  }, [dispatch, fetchOptions]);
+
+  const { setContainerRef, setLoading } = useInfiniteScroll({
+    getMoreItems, dataLength: reviewList.length,
+  });
 
   useEffect(() => {
-    dispatch(setReviews(1, 20, null, true));
+    const { sort } = fetchOptions;
+    dispatch(setReviews(1, 30, sort, true));
     setContainerRef(listRef);
+    // eslint-disable-next-line
   }, [dispatch, setContainerRef]);
 
   const handleClickImage = (reviewId) => {

--- a/src/components/GridView.jsx
+++ b/src/components/GridView.jsx
@@ -25,7 +25,7 @@ function GridView() {
   }, [dispatch, fetchOptions]);
 
   const { setContainerRef, setLoading } = useInfiniteScroll({
-    getMoreItems, dataLength: reviewList.length,
+    getMoreItems, dataLength: reviewList.length, type: 'grid',
   });
 
   useEffect(() => {
@@ -63,12 +63,12 @@ const GridViewWrap = styled.section`
 `;
 
 const ImageBox = styled.img`
-  width: 100%;
-  height: 100%;
-  max-height: calc((500px - 2px) / 3);
-  object-fit: cover;
+  width: calc((500px - 2px) / 3);
+  height: calc((500px - 2px) / 3);
   cursor: pointer;
+  object-fit: cover;
   @media only screen and (max-width: 500px) {
-    max-height: calc((100vw - 2px) / 3);
+    height: calc((100vw - 2px) / 3);
+    width: calc((100vw - 2px) / 3);
   }
 `;

--- a/src/components/GridView.jsx
+++ b/src/components/GridView.jsx
@@ -3,30 +3,31 @@ import {
 } from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
-import PropTypes from 'prop-types';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { setReviews } from '../redux/actions/review';
 import useInfiniteScroll from '../hooks/useInfiniteScroll';
-// import useData from '../hooks/useData';
 
-let page = 0;
-function GridView({ datas }) {
+let page = 1;
+function GridView() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const listRef = useRef();
-  // const fetchData = useData();
-  const getMoreItems = useCallback(async () => {
+  const reviewList = useSelector((state) => state.review.reviews);
+  const sortOption = useSelector((state) => state.review.sortOption);
+
+  const getMoreItems = useCallback(() => {
     setLoading(true);
     page += 1;
-    await dispatch(setReviews(page, 20));
+    dispatch(setReviews(page, 20, sortOption?.value));
     setLoading(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch]);
   const { setContainerRef, setLoading } = useInfiniteScroll({ getMoreItems });
 
   useEffect(() => {
-    getMoreItems();
+    dispatch(setReviews(1, 20, null, true));
     setContainerRef(listRef);
-  }, [getMoreItems, setContainerRef]);
+  }, [dispatch, setContainerRef]);
 
   const handleClickImage = (reviewId) => {
     navigate(`/details/${reviewId}`);
@@ -34,7 +35,7 @@ function GridView({ datas }) {
 
   return (
     <GridViewWrap ref={listRef}>
-      {datas.map((review) => (
+      {reviewList.map((review) => (
         <ImageBox
           key={review.id}
           onClick={() => handleClickImage(review.id)}
@@ -46,10 +47,6 @@ function GridView({ datas }) {
 }
 
 export default memo(GridView);
-
-GridView.propTypes = {
-  datas: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.object])).isRequired,
-};
 
 const GridViewWrap = styled.section`
   width: 100%;

--- a/src/components/ListView/Image.jsx
+++ b/src/components/ListView/Image.jsx
@@ -13,10 +13,15 @@ export default Image;
 
 const ImageArea = styled.div`
   max-width: 500px;
+  height: 40rem;
+  text-align: center;
+  overflow: hidden;
 `;
 
 const Img = styled.img`
-  max-width: 500px;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 `;
 
 Image.propTypes = {

--- a/src/components/ListView/ListNav.jsx
+++ b/src/components/ListView/ListNav.jsx
@@ -29,7 +29,8 @@ const Container = styled.header`
   box-shadow: rgb(204 204 204) 0px 0px px 0px;
   background-color: ${(props) => props.theme.color.white};
   position: fixed;
-  width: 500px;
+  max-width: 500px;
+  width: 100%;
 `;
 
 const Item = styled.div`

--- a/src/components/ListView/ListView.jsx
+++ b/src/components/ListView/ListView.jsx
@@ -1,8 +1,9 @@
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import PropTypes from 'prop-types';
-import { useDispatch } from 'react-redux';
-import { useEffect, useRef, useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  useEffect, useRef, useCallback,
+} from 'react';
 import Content from './Content';
 import Desc from './Desc';
 import Image from './Image';
@@ -12,8 +13,7 @@ import Stars from './Stars';
 import { setReviews } from '../../redux/actions/review';
 import useInfiniteScroll from '../../hooks/useInfiniteScroll';
 
-let page = 0;
-function ListView({ datas }) {
+function ListView() {
   const navigate = useNavigate();
   const detailPageClick = (id) => {
     navigate(`/details/${id}`);
@@ -21,24 +21,31 @@ function ListView({ datas }) {
 
   const dispatch = useDispatch();
   const listRef = useRef();
+  const reviewList = useSelector((state) => state.review.reviews);
+  const fetchOptions = useSelector((state) => state.review.options);
+
   const getMoreItems = useCallback(async () => {
-    setLoading(true);
-    page += 1;
-    await dispatch(setReviews(page, 20, datas));
-    setLoading(false);
+    if (fetchOptions?.pageNo) {
+      const { pageNo, perPage, sort } = fetchOptions;
+      setLoading(true);
+      await dispatch(setReviews(pageNo + 1, perPage, sort));
+      setLoading(false);
+    }
     // eslint-disable-next-line
   }, [dispatch]);
 
   const { setContainerRef, setLoading } = useInfiniteScroll({ getMoreItems });
 
   useEffect(() => {
-    getMoreItems();
+    const { sort } = fetchOptions;
+    dispatch(setReviews(1, 10, sort, true));
     setContainerRef(listRef);
-  }, [getMoreItems, setContainerRef]);
+    // eslint-disable-next-line
+  }, [dispatch, setContainerRef]);
 
   return (
     <>
-      {datas.map((item) => (
+      {reviewList.map((item) => (
         <ListPage
           ref={listRef}
           key={item.id}
@@ -63,7 +70,3 @@ export default ListView;
 const ListPage = styled.div`
   cursor: pointer;
 `;
-
-ListView.propTypes = {
-  datas: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.object])).isRequired,
-};

--- a/src/components/ListView/ListView.jsx
+++ b/src/components/ListView/ListView.jsx
@@ -24,17 +24,20 @@ function ListView() {
   const reviewList = useSelector((state) => state.review.reviews);
   const fetchOptions = useSelector((state) => state.review.options);
 
-  const getMoreItems = useCallback(async () => {
-    if (fetchOptions?.pageNo) {
+  const getMoreItems = useCallback(() => {
+    if ((fetchOptions?.pageNo)) {
       const { pageNo, perPage, sort } = fetchOptions;
       setLoading(true);
-      await dispatch(setReviews(pageNo + 1, perPage, sort));
+      dispatch(setReviews(pageNo + 1, perPage, sort));
       setLoading(false);
     }
     // eslint-disable-next-line
-  }, [dispatch]);
+  }, [dispatch, fetchOptions]);
 
-  const { setContainerRef, setLoading } = useInfiniteScroll({ getMoreItems });
+  const { setContainerRef, setLoading } = useInfiniteScroll({
+    getMoreItems,
+    dataLength: reviewList.length,
+  });
 
   useEffect(() => {
     const { sort } = fetchOptions;
@@ -44,10 +47,9 @@ function ListView() {
   }, [dispatch, setContainerRef]);
 
   return (
-    <>
+    <div ref={listRef}>
       {reviewList.map((item) => (
         <ListPage
-          ref={listRef}
           key={item.id}
           onClick={() => detailPageClick(item.id)}
           onKeyDown={() => detailPageClick(item.id)}
@@ -61,7 +63,7 @@ function ListView() {
           <Content review={item.review} />
         </ListPage>
       ))}
-    </>
+    </div>
   );
 }
 

--- a/src/components/Review.jsx
+++ b/src/components/Review.jsx
@@ -1,11 +1,14 @@
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 import Button from './Button';
 
 function Review() {
   return (
     <ReviewCustom>
       <Text>리뷰</Text>
-      <Button>리뷰등록</Button>
+      <Link to="/register">
+        <Button>리뷰등록</Button>
+      </Link>
     </ReviewCustom>
   );
 }

--- a/src/components/SortArea/RadioOption.jsx
+++ b/src/components/SortArea/RadioOption.jsx
@@ -2,9 +2,11 @@ import { memo } from 'react';
 import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
 
-function RadioOption({ name, checked, onClick }) {
+function RadioOption({
+  name, value, checked, onClick,
+}) {
   return (
-    <RadioRow checked={checked} onClick={() => onClick(name)}>
+    <RadioRow checked={checked} onClick={() => onClick({ name, value })}>
       {name}
       <RadioIcon checked={checked} />
     </RadioRow>
@@ -15,6 +17,7 @@ export default memo(RadioOption);
 
 RadioOption.propTypes = {
   name: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
   checked: PropTypes.bool.isRequired,
   onClick: PropTypes.func.isRequired,
 };

--- a/src/components/SortArea/SortBar.jsx
+++ b/src/components/SortArea/SortBar.jsx
@@ -1,36 +1,40 @@
 import styled from 'styled-components';
-import { useState, useCallback } from 'react';
+import {
+  useState, useCallback, useMemo, useEffect,
+} from 'react';
 import { IoRefreshOutline } from 'react-icons/io5';
 import { useDispatch, useSelector } from 'react-redux';
-import { refreshReviews } from '../../redux/actions/review';
+import { setReviews } from '../../redux/actions/review';
 import Selector from './Selector';
 import SortModal from './SortModal';
 import { RoundedButton } from '../Button';
 import SORT_OPTIONS from '../../constants/sort';
-import useData from '../../hooks/useData';
 
 function SortBar() {
   const dispatch = useDispatch();
-  const fetchData = useData();
-  const sortOption = useSelector(
-    (state) => state.review.sortOption || SORT_OPTIONS[0],
-  );
+  const options = useSelector((state) => state.review.options);
+  const { perPage, sort } = useMemo(() => options, [options]);
   const [isOpenModal, setIsOpenModal] = useState(false);
 
   const toggleModal = useCallback(() => {
     setIsOpenModal((isOpen) => !isOpen);
   }, []);
 
-  const handleClickRefresh = async () => {
-    const data = await fetchData(1, 20);
-    dispatch(refreshReviews(data));
-  };
+  const handleClickRefresh = useCallback(() => {
+    dispatch(setReviews(1, perPage, sort, true));
+  }, [dispatch, perPage, sort]);
+
+  useEffect(() => {
+    if (sort) {
+      handleClickRefresh();
+    }
+  }, [sort, handleClickRefresh]);
 
   return (
     <FilterRow>
       <Selector name="정렬" onClick={toggleModal} />
       <FilterButton>전체</FilterButton>
-      <FilterButton>{sortOption.name}</FilterButton>
+      <FilterButton>{sort?.name || SORT_OPTIONS[0].name}</FilterButton>
       <RefreshButton onClick={handleClickRefresh} />
       {isOpenModal && <SortModal setIsOpenModal={setIsOpenModal} />}
     </FilterRow>

--- a/src/components/SortArea/SortBar.jsx
+++ b/src/components/SortArea/SortBar.jsx
@@ -30,7 +30,7 @@ function SortBar() {
     <FilterRow>
       <Selector name="정렬" onClick={toggleModal} />
       <FilterButton>전체</FilterButton>
-      <FilterButton>{sortOption}</FilterButton>
+      <FilterButton>{sortOption.name}</FilterButton>
       <RefreshButton onClick={handleClickRefresh} />
       {isOpenModal && <SortModal setIsOpenModal={setIsOpenModal} />}
     </FilterRow>

--- a/src/components/SortArea/SortModal.jsx
+++ b/src/components/SortArea/SortModal.jsx
@@ -82,16 +82,17 @@ const SortList = memo(({ sortOption, onChange }) => (
     {SORT_OPTIONS.map((option) => (
       <RadioOption
         onClick={onChange}
-        key={option}
-        name={option}
-        checked={sortOption === option}
+        key={option.value}
+        name={option.name}
+        value={option.value}
+        checked={sortOption?.name === option.name}
       />
     ))}
   </SortListWrap>
 ));
 
 SortList.propTypes = {
-  sortOption: PropTypes.string.isRequired,
+  sortOption: PropTypes.objectOf(PropTypes.string).isRequired,
   onChange: PropTypes.func.isRequired,
 };
 

--- a/src/components/SortArea/SortModal.jsx
+++ b/src/components/SortArea/SortModal.jsx
@@ -1,4 +1,6 @@
-import { memo, useState, useCallback } from 'react';
+import {
+  memo, useState, useCallback, useMemo,
+} from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
@@ -8,8 +10,10 @@ import { setSortOption } from '../../redux/actions/review';
 
 function SortModal({ setIsOpenModal }) {
   const dispatch = useDispatch();
-  const sortOption = useSelector((state) => state.review.sortOption);
-  const [selected, setSelected] = useState(sortOption || SORT_OPTIONS[0]);
+  const fetchOptions = useSelector((state) => state.review.options);
+  const { sort } = useMemo(() => fetchOptions, [fetchOptions]);
+  const [selected, setSelected] = useState(sort || SORT_OPTIONS[0]);
+
   const handleClickApply = () => {
     dispatch(setSortOption(selected));
     toggleModal();

--- a/src/components/Tab.jsx
+++ b/src/components/Tab.jsx
@@ -1,6 +1,5 @@
 import { BsGrid3X3, BsViewList } from 'react-icons/bs';
-import { useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { memo, useState } from 'react';
 import styled from 'styled-components';
 import GridView from './GridView';
 import ListView from './ListView/ListView';
@@ -10,36 +9,8 @@ const iconList = [
   { index: 1, icon: <BsViewList /> },
 ];
 
-const sortRandom = (arr) => arr.sort(() => Math.random() - 0.5);
-const sortLikes = (arr) => arr.sort((a, b) => a.likes - b.likes);
-const sortComments = (arr) => arr.sort((a, b) => a.comments.length - b.comments.length);
-
 function Tab() {
   const [currentTab, setCurrentTab] = useState(0);
-  const reviewList = useSelector((state) => state.review.reviews);
-  const sortOption = useSelector((state) => state.review.sortOption);
-  const [sortedReviews, setSortedReviews] = useState(reviewList);
-  useEffect(() => {
-    setSortedReviews(reviewList);
-  }, [reviewList]);
-  useEffect(() => {
-    if (sortOption) {
-      const originReviews = [...reviewList];
-      switch (sortOption) {
-        case '좋아요 많은순':
-          return setSortedReviews(sortLikes(originReviews));
-        case '댓글 많은순':
-          return setSortedReviews(sortComments(originReviews));
-        case '랜덤순':
-          return setSortedReviews(sortRandom(originReviews));
-        default:
-          return setSortedReviews(originReviews);
-      }
-    } else {
-      return false;
-    }
-  }, [sortOption, reviewList]);
-
   return (
     <TabWrap>
       <TabRow>
@@ -54,12 +25,12 @@ function Tab() {
           </TabItem>
         ))}
       </TabRow>
-      {currentTab === 0 ? <GridView datas={sortedReviews} /> : <ListView />}
+      {currentTab === 0 ? <GridView /> : <ListView />}
     </TabWrap>
   );
 }
 
-export default Tab;
+export default memo(Tab);
 const TabWrap = styled.section``;
 
 const TabRow = styled.section`

--- a/src/constants/sort.js
+++ b/src/constants/sort.js
@@ -1,8 +1,8 @@
 const SORT_OPTIONS = Object.freeze([
-  '최신순',
-  '좋아요 많은순',
-  '댓글 많은순',
-  '랜덤순',
+  { name: '최신순', value: 'recent' },
+  { name: '좋아요 많은순', value: 'likes' },
+  { name: '댓글 많은순', value: 'comments' },
+  { name: '랜덤순', value: 'random' },
 ]);
 
 SORT_OPTIONS.forEach(Object.freeze);

--- a/src/hooks/useInfiniteScroll.js
+++ b/src/hooks/useInfiniteScroll.js
@@ -27,7 +27,7 @@ const useInfiniteScroll = ({ dataLength, getMoreItems }) => {
     }
     return () => observer?.disconnect();
     // eslint-disable-next-line
-  }, [dataLength]);
+  }, [dataLength, containerRef]);
 
   return {
     containerRef,

--- a/src/hooks/useInfiniteScroll.js
+++ b/src/hooks/useInfiniteScroll.js
@@ -1,16 +1,13 @@
 import { useEffect, useState, useCallback } from 'react';
 
-const useInfiniteScroll = ({ getMoreItems }) => {
+const useInfiniteScroll = ({ dataLength, getMoreItems }) => {
   const [containerRef, setContainerRef] = useState(null);
   const [loading, setLoading] = useState(false);
-
   const onIntersect = useCallback(
     async ([entry], observer) => {
       if (entry.isIntersecting && !loading) {
-        setLoading(true);
         observer.unobserve(entry.target);
         await getMoreItems();
-        setLoading(false);
       }
     },
     [getMoreItems, loading],
@@ -29,7 +26,8 @@ const useInfiniteScroll = ({ getMoreItems }) => {
       observer.observe(target);
     }
     return () => observer?.disconnect();
-  });
+    // eslint-disable-next-line
+  }, [dataLength]);
 
   return {
     containerRef,

--- a/src/hooks/useInfiniteScroll.js
+++ b/src/hooks/useInfiniteScroll.js
@@ -4,15 +4,17 @@ const useInfiniteScroll = ({ getMoreItems }) => {
   const [containerRef, setContainerRef] = useState(null);
   const [loading, setLoading] = useState(false);
 
-  const onIntersect = useCallback(async ([entry], observer) => {
-    if (entry.isIntersecting && !loading) {
-      setLoading(true);
-      observer.unobserve(entry.target);
-      await getMoreItems();
-      observer.observe(entry.target);
-      setLoading(false);
-    }
-  }, [getMoreItems, loading]);
+  const onIntersect = useCallback(
+    async ([entry], observer) => {
+      if (entry.isIntersecting && !loading) {
+        setLoading(true);
+        observer.unobserve(entry.target);
+        await getMoreItems();
+        setLoading(false);
+      }
+    },
+    [getMoreItems, loading],
+  );
 
   useEffect(() => {
     if (!containerRef?.current) {
@@ -30,7 +32,10 @@ const useInfiniteScroll = ({ getMoreItems }) => {
   });
 
   return {
-    containerRef, setContainerRef, loading, setLoading,
+    containerRef,
+    setContainerRef,
+    loading,
+    setLoading,
   };
 };
 

--- a/src/pages/ReviewDetailsPage.jsx
+++ b/src/pages/ReviewDetailsPage.jsx
@@ -39,6 +39,7 @@ const Detail = styled.div`
   top: 0;
   z-index: 50;
   background-color: ${(props) => props.theme.color.white};
+  max-width: 100%;
 `;
 
 const Comments = styled.div`

--- a/src/redux/actions/review.js
+++ b/src/redux/actions/review.js
@@ -12,19 +12,23 @@ const SERVER_LESS_API = 'https://asia-northeast3-team-projects-343711.cloudfunct
 
 export const setReviews = async (pageNo, perPage, sort, isInit) => {
   const request = await axios
-    .get(SERVER_LESS_API, { params: { pageNo, perPage, sort } })
+    .get(SERVER_LESS_API, { params: { pageNo, perPage, sort: sort?.value } })
     .then((res) => res.data)
     .catch((error) => error);
   return {
     type: SET_REVIEWS,
     payload: request,
-    isInit,
+    options: {
+      pageNo,
+      perPage,
+      sort,
+      isInit,
+    },
   };
 };
 
-export const refreshReviews = (datas) => ({
+export const refreshReviews = () => ({
   type: REFRESH_REVIEWS,
-  payload: datas,
 });
 
 export const addReview = (review) => ({

--- a/src/redux/actions/review.js
+++ b/src/redux/actions/review.js
@@ -10,14 +10,15 @@ import {
 
 const SERVER_LESS_API = 'https://asia-northeast3-team-projects-343711.cloudfunctions.net/balaan-crawler-dev-contents';
 
-export const setReviews = (pageNo, perPage) => {
-  const request = axios
-    .get(SERVER_LESS_API, { params: { pageNo, perPage } })
+export const setReviews = async (pageNo, perPage, sort, isInit) => {
+  const request = await axios
+    .get(SERVER_LESS_API, { params: { pageNo, perPage, sort } })
     .then((res) => res.data)
     .catch((error) => error);
   return {
     type: SET_REVIEWS,
     payload: request,
+    isInit,
   };
 };
 

--- a/src/redux/reducers/review.js
+++ b/src/redux/reducers/review.js
@@ -9,15 +9,15 @@ import {
 
 const initialState = {
   reviews: [],
-  sortOption: null,
+  options: {},
 };
 export default function review(state = initialState, action = {}) {
   switch (action.type) {
     case SET_REVIEWS: {
-      const newDatas = action.isInit ? action.payload
+      const newDatas = action.options.isInit ? action.payload
         : [...state.reviews, ...action.payload];
       return {
-        ...state,
+        options: action.options,
         reviews: newDatas.reduce((acc, current) => {
           if (acc.findIndex(({ id }) => id === current.id) === -1) {
             acc.push(current);
@@ -54,7 +54,7 @@ export default function review(state = initialState, action = {}) {
     case SET_SORT_OPTION:
       return {
         ...state,
-        sortOption: action.payload,
+        options: { ...state.options, sort: action.payload },
       };
     default:
       return state;

--- a/src/redux/reducers/review.js
+++ b/src/redux/reducers/review.js
@@ -16,12 +16,12 @@ export default function review(state = initialState, action = {}) {
     case SET_REVIEWS:
       return {
         ...state,
-        reviews: [...state.reviews, ...action.payload],
+        reviews: action.isInit ? action.payload : [...state.reviews, ...action.payload],
       };
     case REFRESH_REVIEWS:
       return {
         ...state,
-        reviews: action.payload,
+        reviews: [],
       };
     case ADD_REVIEW: {
       return {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [X] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
1. sort query와 정렬 기능이 연동될 수 있도록 수정했습니다.
   - 정렬 옵션 적용 상태에서 refresh, 혹은 리스트뷰 보기로 변경 시에도 정렬 옵션 유지를 위해 redux 관련 코드들을 수정했습니다.
2. 무한 스크롤 시에 target이 정상적으로 변경되지 않는 문제
(이 문제로 인해 getMoreItems가 순간적으로 많이 호출되었고 pageNo 값이 업데이트되기도 이전에 재실행되어 중복 데이터가 발생했습니다.)
<img width="400px" alt="스크린샷 2022-03-12 오전 11 56 59" src="https://user-images.githubusercontent.com/50618754/158001254-5564f634-1dd0-40f2-9943-9d5fa195ae87.png">

   - 무한 스크롤 내부 코드의 useEffect의 dependency 배열로 dataLength 추가
   - 용량이 큰 이미지를 로딩 중일 때 제 영역을 차지하지 않아 목표 target이 렌더링 후에는 화면 밖에 있음에도 이미지가 로딩 중일 떄에는 화면 안에 있는 것으로 인식됨. => image max-width, max-height 대신 width,height 부여

* 위처럼 해결을 했으나 실제 받아오는 데이터에서 중복된 데이터가 있어 예지님께서 작성해주신 중복 제거 코드는 그대로 사용했습니다!
<img width="398" alt="스크린샷 2022-03-12 오전 11 12 20" src="https://user-images.githubusercontent.com/50618754/158001544-8b91ea4e-c26c-47d6-bad4-f00b975c35e9.png">

3. ListView ref 수정 및 mobile 화면 고려 위해 레이아웃 수정했습니다.

### 테스트 결과

https://user-images.githubusercontent.com/50618754/158001574-de508762-e4e3-4ac9-ace8-18d9e67716ea.mov



영상처럼 target이 스크롤에 맞게 한 번씩만 변동되는 걸 확인하실 수 있습니다.